### PR TITLE
feat: R-Streamの3つのモード画面を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 **/.DS_Store
+.cursor
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,9 +11,9 @@
     "lint-staged": "lint-staged --config .lintstagedrc.js"
   },
   "dependencies": {
-    "@mui/icons-material": "^7.1.2",
     "@tailwindcss/vite": "^4.1.8",
     "@tanstack/react-router": "^1.120.11",
+    "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.8"

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -7,15 +7,15 @@ settings:
 importers:
   .:
     dependencies:
-      '@mui/icons-material':
-        specifier: ^7.1.2
-        version: 7.1.2(@mui/material@7.1.2(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.5)(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.1.8(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0))
       '@tanstack/react-router':
         specifier: ^1.120.11
         version: 1.120.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      lucide-react:
+        specifier: ^0.525.0
+        version: 0.525.0(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -379,13 +379,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.27.6':
-    resolution:
-      {
-        integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
-      }
-    engines: { node: '>=6.9.0' }
-
   '@babel/template@7.27.2':
     resolution:
       {
@@ -411,54 +404,6 @@ packages:
     resolution:
       {
         integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
-      }
-
-  '@emotion/cache@11.14.0':
-    resolution:
-      {
-        integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
-      }
-
-  '@emotion/hash@0.9.2':
-    resolution:
-      {
-        integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
-      }
-
-  '@emotion/memoize@0.9.0':
-    resolution:
-      {
-        integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
-      }
-
-  '@emotion/serialize@1.3.3':
-    resolution:
-      {
-        integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
-      }
-
-  '@emotion/sheet@1.4.0':
-    resolution:
-      {
-        integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
-      }
-
-  '@emotion/unitless@0.10.0':
-    resolution:
-      {
-        integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
-      }
-
-  '@emotion/utils@1.4.2':
-    resolution:
-      {
-        integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
-      }
-
-  '@emotion/weak-memoize@0.4.0':
-    resolution:
-      {
-        integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
       }
 
   '@esbuild/aix-ppc64@0.25.4':
@@ -948,121 +893,6 @@ packages:
         integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
       }
 
-  '@mui/core-downloads-tracker@7.1.2':
-    resolution:
-      {
-        integrity: sha512-0gLO1PvbJwSYe5ji021tGj6HFqrtEPMGKK4L1zWwRbhzrWWUumUJvMvJUsIgWQIYQsgOnhq9k2Fc1BxLGHDsAg==
-      }
-
-  '@mui/icons-material@7.1.2':
-    resolution:
-      {
-        integrity: sha512-slqJByDub7Y1UcokrM17BoMBMvn8n7daXFXVoTv0MEH5k3sHjmsH8ql/Mt3s9vQ20cORDr83UZ448TEGcbrXtw==
-      }
-    engines: { node: '>=14.0.0' }
-    peerDependencies:
-      '@mui/material': ^7.1.2
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/material@7.1.2':
-    resolution:
-      {
-        integrity: sha512-Z5PYKkA6Kd8vS04zKxJNpwuvt6IoMwqpbidV7RCrRQQKwczIwcNcS8L6GnN4pzFYfEs+N9v6co27DmG07rcnoA==
-      }
-    engines: { node: '>=14.0.0' }
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@mui/material-pigment-css': ^7.1.1
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@mui/material-pigment-css':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@mui/private-theming@7.1.1':
-    resolution:
-      {
-        integrity: sha512-M8NbLUx+armk2ZuaxBkkMk11ultnWmrPlN0Xe3jUEaBChg/mcxa5HWIWS1EE4DF36WRACaAHVAvyekWlDQf0PQ==
-      }
-    engines: { node: '>=14.0.0' }
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/styled-engine@7.1.1':
-    resolution:
-      {
-        integrity: sha512-R2wpzmSN127j26HrCPYVQ53vvMcT5DaKLoWkrfwUYq3cYytL6TQrCH8JBH3z79B6g4nMZZVoaXrxO757AlShaw==
-      }
-    engines: { node: '>=14.0.0' }
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-
-  '@mui/system@7.1.1':
-    resolution:
-      {
-        integrity: sha512-Kj1uhiqnj4Zo7PDjAOghtXJtNABunWvhcRU0O7RQJ7WOxeynoH6wXPcilphV8QTFtkKaip8EiNJRiCD+B3eROA==
-      }
-    engines: { node: '>=14.0.0' }
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@mui/types@7.4.3':
-    resolution:
-      {
-        integrity: sha512-2UCEiK29vtiZTeLdS2d4GndBKacVyxGvReznGXGr+CzW/YhjIX+OHUdCIczZjzcRAgKBGmE9zCIgoV9FleuyRQ==
-      }
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@7.1.1':
-    resolution:
-      {
-        integrity: sha512-BkOt2q7MBYl7pweY2JWwfrlahhp+uGLR8S+EhiyRaofeRYUWL2YKbSGQvN4hgSN1i8poN0PaUiii1kEMrchvzg==
-      }
-    engines: { node: '>=14.0.0' }
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     resolution:
       {
@@ -1083,12 +913,6 @@ packages:
         integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
       }
     engines: { node: '>= 8' }
-
-  '@popperjs/core@2.11.8':
-    resolution:
-      {
-        integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
-      }
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution:
@@ -1707,12 +1531,6 @@ packages:
         integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
       }
 
-  '@types/prop-types@15.7.15':
-    resolution:
-      {
-        integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
-      }
-
   '@types/react-dom@19.1.5':
     resolution:
       {
@@ -1720,14 +1538,6 @@ packages:
       }
     peerDependencies:
       '@types/react': ^19.0.0
-
-  '@types/react-transition-group@4.4.12':
-    resolution:
-      {
-        integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
-      }
-    peerDependencies:
-      '@types/react': '*'
 
   '@types/react@19.1.5':
     resolution:
@@ -2237,13 +2047,6 @@ packages:
       }
     engines: { node: '>=12' }
 
-  clsx@2.1.1:
-    resolution:
-      {
-        integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
-      }
-    engines: { node: '>=6' }
-
   co@4.6.0:
     resolution:
       {
@@ -2436,12 +2239,6 @@ packages:
     resolution:
       {
         integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
-      }
-
-  dom-helpers@5.2.1:
-    resolution:
-      {
-        integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
       }
 
   domexception@4.0.0:
@@ -3748,13 +3545,6 @@ packages:
       }
     engines: { node: '>=18' }
 
-  loose-envify@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-      }
-    hasBin: true
-
   lru-cache@10.4.3:
     resolution:
       {
@@ -3766,6 +3556,14 @@ packages:
       {
         integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
       }
+
+  lucide-react@0.525.0:
+    resolution:
+      {
+        integrity: sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==
+      }
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.17:
     resolution:
@@ -3968,13 +3766,6 @@ packages:
       {
         integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==
       }
-
-  object-assign@4.1.1:
-    resolution:
-      {
-        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-      }
-    engines: { node: '>=0.10.0' }
 
   once@1.4.0:
     resolution:
@@ -4255,12 +4046,6 @@ packages:
       }
     engines: { node: '>= 6' }
 
-  prop-types@15.8.1:
-    resolution:
-      {
-        integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
-      }
-
   psl@1.15.0:
     resolution:
       {
@@ -4306,22 +4091,10 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
-  react-is@16.13.1:
-    resolution:
-      {
-        integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-      }
-
   react-is@18.3.1:
     resolution:
       {
         integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
-      }
-
-  react-is@19.1.0:
-    resolution:
-      {
-        integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==
       }
 
   react-refresh@0.17.0:
@@ -4330,15 +4103,6 @@ packages:
         integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
       }
     engines: { node: '>=0.10.0' }
-
-  react-transition-group@4.4.5:
-    resolution:
-      {
-        integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
-      }
-    peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
 
   react@19.1.0:
     resolution:
@@ -4705,12 +4469,6 @@ packages:
     resolution:
       {
         integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==
-      }
-
-  stylis@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
       }
 
   supports-color@7.2.0:
@@ -5421,8 +5179,6 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/runtime@7.27.6': {}
-
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -5447,34 +5203,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
-
-  '@emotion/cache@11.14.0':
-    dependencies:
-      '@emotion/memoize': 0.9.0
-      '@emotion/sheet': 1.4.0
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      stylis: 4.2.0
-
-  '@emotion/hash@0.9.2': {}
-
-  '@emotion/memoize@0.9.0': {}
-
-  '@emotion/serialize@1.3.3':
-    dependencies:
-      '@emotion/hash': 0.9.2
-      '@emotion/memoize': 0.9.0
-      '@emotion/unitless': 0.10.0
-      '@emotion/utils': 1.4.2
-      csstype: 3.1.3
-
-  '@emotion/sheet@1.4.0': {}
-
-  '@emotion/unitless@0.10.0': {}
-
-  '@emotion/utils@1.4.2': {}
-
-  '@emotion/weak-memoize@0.4.0': {}
 
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
@@ -5801,86 +5529,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mui/core-downloads-tracker@7.1.2': {}
-
-  '@mui/icons-material@7.1.2(@mui/material@7.1.2(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.5)(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/material': 7.1.2(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.1.5
-
-  '@mui/material@7.1.2(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/core-downloads-tracker': 7.1.2
-      '@mui/system': 7.1.1(@types/react@19.1.5)(react@19.1.0)
-      '@mui/types': 7.4.3(@types/react@19.1.5)
-      '@mui/utils': 7.1.1(@types/react@19.1.5)(react@19.1.0)
-      '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@19.1.5)
-      clsx: 2.1.1
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-is: 19.1.0
-      react-transition-group: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 19.1.5
-
-  '@mui/private-theming@7.1.1(@types/react@19.1.5)(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/utils': 7.1.1(@types/react@19.1.5)(react@19.1.0)
-      prop-types: 15.8.1
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.1.5
-
-  '@mui/styled-engine@7.1.1(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/sheet': 1.4.0
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 19.1.0
-
-  '@mui/system@7.1.1(@types/react@19.1.5)(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/private-theming': 7.1.1(@types/react@19.1.5)(react@19.1.0)
-      '@mui/styled-engine': 7.1.1(react@19.1.0)
-      '@mui/types': 7.4.3(@types/react@19.1.5)
-      '@mui/utils': 7.1.1(@types/react@19.1.5)(react@19.1.0)
-      clsx: 2.1.1
-      csstype: 3.1.3
-      prop-types: 15.8.1
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.1.5
-
-  '@mui/types@7.4.3(@types/react@19.1.5)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-    optionalDependencies:
-      '@types/react': 19.1.5
-
-  '@mui/utils@7.1.1(@types/react@19.1.5)(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.6
-      '@mui/types': 7.4.3(@types/react@19.1.5)
-      '@types/prop-types': 15.7.15
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.1.0
-      react-is: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.1.5
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5892,8 +5540,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
-
-  '@popperjs/core@2.11.8': {}
 
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
@@ -6278,13 +5924,7 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@types/prop-types@15.7.15': {}
-
   '@types/react-dom@19.1.5(@types/react@19.1.5)':
-    dependencies:
-      '@types/react': 19.1.5
-
-  '@types/react-transition-group@4.4.12(@types/react@19.1.5)':
     dependencies:
       '@types/react': 19.1.5
 
@@ -6638,8 +6278,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  clsx@2.1.1: {}
-
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.2: {}
@@ -6724,11 +6362,6 @@ snapshots:
   diff@7.0.0: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  dom-helpers@5.2.1:
-    dependencies:
-      '@babel/runtime': 7.27.6
-      csstype: 3.1.3
 
   domexception@4.0.0:
     dependencies:
@@ -7718,15 +7351,15 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
-
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.525.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   magic-string@0.30.17:
     dependencies:
@@ -7812,8 +7445,6 @@ snapshots:
       path-key: 3.1.1
 
   nwsapi@2.2.20: {}
-
-  object-assign@4.1.1: {}
 
   once@1.4.0:
     dependencies:
@@ -7934,12 +7565,6 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -7966,22 +7591,9 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-is@16.13.1: {}
-
   react-is@18.3.1: {}
 
-  react-is@19.1.0: {}
-
   react-refresh@0.17.0: {}
-
-  react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.27.6
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
 
@@ -8190,8 +7802,6 @@ snapshots:
   structured-source@4.0.0:
     dependencies:
       boundary: 2.0.0
-
-  stylis@4.2.0: {}
 
   supports-color@7.2.0:
     dependencies:

--- a/apps/web/src/components.tsx
+++ b/apps/web/src/components.tsx
@@ -1,6 +1,13 @@
 import { useState, memo } from 'react';
 import { useRouter, useCanGoBack } from '@tanstack/react-router';
-import { AlignLeft, ArrowLeft } from 'lucide-react';
+import {
+  AlignLeft,
+  ArrowLeft,
+  Link,
+  Presentation,
+  Video,
+  MessagesSquare
+} from 'lucide-react';
 
 type HeaderProps = {
   title: string;
@@ -76,3 +83,42 @@ const Header: React.FC<HeaderProps> = memo(({ title }) => {
     </>
   );
 });
+
+// プレゼンテーションモードボタン
+export function PresentationModeButton() {
+  return (
+    <Link
+      to='/presentation'
+      className='flex items-center gap-3 rounded-lg border p-4 transition-colors hover:bg-gray-50'
+    >
+      <Presentation className='h-6 w-6 text-blue-600' />
+      <span>プレゼンテーションモードを作成する</span>
+    </Link>
+  );
+}
+
+// 動画聴講モードボタン
+export function WatchVideoModeButton() {
+  return (
+    <Link
+      to='/watch_video'
+      className='flex items-center gap-3 rounded-lg border p-4 transition-colors hover:bg-gray-50'
+    >
+      <Video className='h-6 w-6 text-blue-600' />
+      <span>動画聴講モードを作成する</span>
+    </Link>
+  );
+}
+
+// ディスカッションモードボタン
+export function DiscussionModeButton() {
+  return (
+    <Link
+      to='/discussion'
+      className='flex items-center gap-3 rounded-lg border p-4 transition-colors hover:bg-gray-50'
+    >
+      <MessagesSquare className='h-6 w-6 text-blue-600' />
+      <span>ディスカッションモードを作成する</span>
+    </Link>
+  );
+}

--- a/apps/web/src/components.tsx
+++ b/apps/web/src/components.tsx
@@ -1,7 +1,6 @@
 import { useState, memo } from 'react';
 import { useRouter, useCanGoBack } from '@tanstack/react-router';
-import ViewListIcon from '@mui/icons-material/ViewList';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { AlignLeft, ArrowLeft } from 'lucide-react';
 
 type HeaderProps = {
   title: string;
@@ -14,14 +13,14 @@ const Header: React.FC<HeaderProps> = memo(({ title }) => {
   const router = useRouter();
   const handleMenuClick = () => setIsMenuOpen((prev: boolean) => !prev);
 
-  // 戻るボタンの表示判定(2重否定でboolean型に変換) - fromパラメータが存在する場合に表示
+  // 戻るボタンの表示判定
   const canGoBack = useCanGoBack();
 
   // 左側のボタン管理 - map関数を使用するために配列で管理、オプションの有無によって動的に調整
   const leftButtons = [
     {
       // 1つ目のボタン：メニュー（常に表示）
-      icon: ViewListIcon,
+      icon: AlignLeft,
       onClick: handleMenuClick,
       key: 'menu'
     },
@@ -29,7 +28,7 @@ const Header: React.FC<HeaderProps> = memo(({ title }) => {
     ...(canGoBack
       ? [
           {
-            icon: ArrowBackIcon,
+            icon: ArrowLeft,
             onClick: () => router.history.back(),
             key: 'back'
           }

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,19 +1,10 @@
 import { useState, memo } from 'react';
 import { useRouter, useCanGoBack } from '@tanstack/react-router';
-import {
-  AlignLeft,
-  ArrowLeft,
-  Link,
-  Presentation,
-  Video,
-  MessagesSquare
-} from 'lucide-react';
+import { AlignLeft, ArrowLeft } from 'lucide-react';
 
 type HeaderProps = {
   title: string;
 };
-
-export { Header };
 
 const Header: React.FC<HeaderProps> = memo(({ title }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -84,41 +75,4 @@ const Header: React.FC<HeaderProps> = memo(({ title }) => {
   );
 });
 
-// プレゼンテーションモードボタン
-export function PresentationModeButton() {
-  return (
-    <Link
-      to='/presentation'
-      className='flex items-center gap-3 rounded-lg border p-4 transition-colors hover:bg-gray-50'
-    >
-      <Presentation className='h-6 w-6 text-blue-600' />
-      <span>プレゼンテーションモードを作成する</span>
-    </Link>
-  );
-}
-
-// 動画聴講モードボタン
-export function WatchVideoModeButton() {
-  return (
-    <Link
-      to='/watch_video'
-      className='flex items-center gap-3 rounded-lg border p-4 transition-colors hover:bg-gray-50'
-    >
-      <Video className='h-6 w-6 text-blue-600' />
-      <span>動画聴講モードを作成する</span>
-    </Link>
-  );
-}
-
-// ディスカッションモードボタン
-export function DiscussionModeButton() {
-  return (
-    <Link
-      to='/discussion'
-      className='flex items-center gap-3 rounded-lg border p-4 transition-colors hover:bg-gray-50'
-    >
-      <MessagesSquare className='h-6 w-6 text-blue-600' />
-      <span>ディスカッションモードを作成する</span>
-    </Link>
-  );
-}
+export { Header };

--- a/apps/web/src/components/ModeButton.tsx
+++ b/apps/web/src/components/ModeButton.tsx
@@ -13,7 +13,7 @@ const ModeButton: React.FC<ModeButtonProps> = ({ to, text, icon }) => {
       to={to}
       className={`flex items-center justify-center gap-1 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700`}
     >
-      {icon}
+      <div className='h-6 w-6 text-white'>{icon}</div>
       <span>{text}</span>
     </Link>
   );

--- a/apps/web/src/components/ModeButton.tsx
+++ b/apps/web/src/components/ModeButton.tsx
@@ -1,0 +1,46 @@
+import { Link } from '@tanstack/react-router';
+import { Speech, Video, MessagesSquare } from 'lucide-react';
+
+type ModeButtonProps = {
+  to: string; // 遷移先パス
+  text: string; // ボタンテキスト
+  children: React.ReactNode; // アイコン
+};
+
+// ボタンコンポーネント
+const ModeButton: React.FC<ModeButtonProps> = ({ to, text, children }) => {
+  return (
+    <Link
+      to={to}
+      className={`flex items-center justify-center gap-1 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700`}
+    >
+      {children}
+      <span>{text}</span>
+    </Link>
+  );
+};
+
+// 各モード用のエクスポート関数 //////////////////////////////////////////////////////
+
+// プレゼンテーションモードボタン
+export const PresentationModeButton = () => (
+  <ModeButton to='/presentation' text='プレゼンテーションモードを作成する'>
+    <Speech className='h-6 w-6 text-white' />
+  </ModeButton>
+);
+
+// 動画聴講モードボタン
+export const WatchVideoModeButton = () => (
+  <ModeButton to='/watch_video' text='動画聴講モードを作成する'>
+    <Video className='h-6 w-6 text-white' />
+  </ModeButton>
+);
+
+// ディスカッションモードボタン
+export const DiscussionModeButton = () => (
+  <ModeButton to='/discussion' text='ディスカッションモードを作成する'>
+    <MessagesSquare className='h-6 w-6 text-white' />
+  </ModeButton>
+);
+
+export { ModeButton };

--- a/apps/web/src/components/ModeButton.tsx
+++ b/apps/web/src/components/ModeButton.tsx
@@ -1,21 +1,19 @@
 import { Link } from '@tanstack/react-router';
-import { Speech, Video, MessagesSquare } from 'lucide-react';
+import { Speech, TvMinimalPlay, MessagesSquare } from 'lucide-react';
 
 type ModeButtonProps = {
   to: string; // 遷移先パス
-  text: string; // ボタンテキスト
-  children: React.ReactNode; // アイコン
+  children: React.ReactNode; // アイコン + テキスト
 };
 
 // ボタンコンポーネント
-const ModeButton: React.FC<ModeButtonProps> = ({ to, text, children }) => {
+const ModeButton: React.FC<ModeButtonProps> = ({ to, children }) => {
   return (
     <Link
       to={to}
       className={`flex items-center justify-center gap-1 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700`}
     >
       {children}
-      <span>{text}</span>
     </Link>
   );
 };
@@ -24,22 +22,25 @@ const ModeButton: React.FC<ModeButtonProps> = ({ to, text, children }) => {
 
 // プレゼンテーションモードボタン
 export const PresentationModeButton = () => (
-  <ModeButton to='/presentation' text='プレゼンテーションモードを作成する'>
+  <ModeButton to='/presentation'>
     <Speech className='h-6 w-6 text-white' />
+    プレゼンテーションモードを作成する
   </ModeButton>
 );
 
 // 動画聴講モードボタン
 export const WatchVideoModeButton = () => (
-  <ModeButton to='/watch_video' text='動画聴講モードを作成する'>
-    <Video className='h-6 w-6 text-white' />
+  <ModeButton to='/watch_video'>
+    <TvMinimalPlay className='h-6 w-6 text-white' />
+    動画聴講モードを作成する
   </ModeButton>
 );
 
 // ディスカッションモードボタン
 export const DiscussionModeButton = () => (
-  <ModeButton to='/discussion' text='ディスカッションモードを作成する'>
+  <ModeButton to='/discussion'>
     <MessagesSquare className='h-6 w-6 text-white' />
+    ディスカッションモードを作成する
   </ModeButton>
 );
 

--- a/apps/web/src/components/ModeButton.tsx
+++ b/apps/web/src/components/ModeButton.tsx
@@ -1,55 +1,22 @@
 import { Link } from '@tanstack/react-router';
-import { Speech, TvMinimalPlay, MessagesSquare } from 'lucide-react';
 
 type ModeButtonProps = {
   to: string; // 遷移先パス
+  text: string; // テキスト
   icon: React.ReactNode; // アイコン
-  children: React.ReactNode; // テキスト
 };
 
 // ボタンコンポーネント
-const ModeButton: React.FC<ModeButtonProps> = ({ to, icon, children }) => {
+const ModeButton: React.FC<ModeButtonProps> = ({ to, text, icon }) => {
   return (
     <Link
       to={to}
       className={`flex items-center justify-center gap-1 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700`}
     >
       {icon}
-      <span>{children}</span>
+      <span>{text}</span>
     </Link>
   );
 };
-
-// 各モード用のエクスポート関数 //////////////////////////////////////////////////////
-
-// プレゼンテーションモードボタン
-export const PresentationModeButton = () => (
-  <ModeButton
-    to='/presentation'
-    icon={<Speech className='h-6 w-6 text-white' />}
-  >
-    プレゼンテーションモードを作成する
-  </ModeButton>
-);
-
-// 動画聴講モードボタン
-export const WatchVideoModeButton = () => (
-  <ModeButton
-    to='/watch_video'
-    icon={<TvMinimalPlay className='h-6 w-6 text-white' />}
-  >
-    動画聴講モードを作成する
-  </ModeButton>
-);
-
-// ディスカッションモードボタン
-export const DiscussionModeButton = () => (
-  <ModeButton
-    to='/discussion'
-    icon={<MessagesSquare className='h-6 w-6 text-white' />}
-  >
-    ディスカッションモードを作成する
-  </ModeButton>
-);
 
 export { ModeButton };

--- a/apps/web/src/components/ModeButton.tsx
+++ b/apps/web/src/components/ModeButton.tsx
@@ -3,17 +3,19 @@ import { Speech, TvMinimalPlay, MessagesSquare } from 'lucide-react';
 
 type ModeButtonProps = {
   to: string; // 遷移先パス
-  children: React.ReactNode; // アイコン + テキスト
+  icon: React.ReactNode; // アイコン
+  children: React.ReactNode; // テキスト
 };
 
 // ボタンコンポーネント
-const ModeButton: React.FC<ModeButtonProps> = ({ to, children }) => {
+const ModeButton: React.FC<ModeButtonProps> = ({ to, icon, children }) => {
   return (
     <Link
       to={to}
       className={`flex items-center justify-center gap-1 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700`}
     >
-      {children}
+      {icon}
+      <span>{children}</span>
     </Link>
   );
 };
@@ -22,24 +24,30 @@ const ModeButton: React.FC<ModeButtonProps> = ({ to, children }) => {
 
 // プレゼンテーションモードボタン
 export const PresentationModeButton = () => (
-  <ModeButton to='/presentation'>
-    <Speech className='h-6 w-6 text-white' />
+  <ModeButton
+    to='/presentation'
+    icon={<Speech className='h-6 w-6 text-white' />}
+  >
     プレゼンテーションモードを作成する
   </ModeButton>
 );
 
 // 動画聴講モードボタン
 export const WatchVideoModeButton = () => (
-  <ModeButton to='/watch_video'>
-    <TvMinimalPlay className='h-6 w-6 text-white' />
+  <ModeButton
+    to='/watch_video'
+    icon={<TvMinimalPlay className='h-6 w-6 text-white' />}
+  >
     動画聴講モードを作成する
   </ModeButton>
 );
 
 // ディスカッションモードボタン
 export const DiscussionModeButton = () => (
-  <ModeButton to='/discussion'>
-    <MessagesSquare className='h-6 w-6 text-white' />
+  <ModeButton
+    to='/discussion'
+    icon={<MessagesSquare className='h-6 w-6 text-white' />}
+  >
     ディスカッションモードを作成する
   </ModeButton>
 );

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,7 +1,2 @@
 export { Header } from './Header';
-export {
-  ModeButton,
-  PresentationModeButton,
-  WatchVideoModeButton,
-  DiscussionModeButton
-} from './ModeButton';
+export { ModeButton } from './ModeButton';

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,0 +1,7 @@
+export { Header } from './Header';
+export {
+  ModeButton,
+  PresentationModeButton,
+  WatchVideoModeButton,
+  DiscussionModeButton
+} from './ModeButton';

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,7 +11,10 @@
 // Import Routes
 
 import { Route as rootRoute } from './routes/__root';
+import { Route as WatchvideoImport } from './routes/watch_video';
+import { Route as PresentationImport } from './routes/presentation';
 import { Route as JoinImport } from './routes/join';
+import { Route as DiscussionImport } from './routes/discussion';
 import { Route as CreateImport } from './routes/create';
 import { Route as IndexImport } from './routes/index';
 import { Route as PublicLoginImport } from './routes/_public/login';
@@ -19,9 +22,27 @@ import { Route as AuthHomeImport } from './routes/_auth/home';
 
 // Create/Update Routes
 
+const WatchvideoRoute = WatchvideoImport.update({
+  id: '/watch_video',
+  path: '/watch_video',
+  getParentRoute: () => rootRoute
+} as any);
+
+const PresentationRoute = PresentationImport.update({
+  id: '/presentation',
+  path: '/presentation',
+  getParentRoute: () => rootRoute
+} as any);
+
 const JoinRoute = JoinImport.update({
   id: '/join',
   path: '/join',
+  getParentRoute: () => rootRoute
+} as any);
+
+const DiscussionRoute = DiscussionImport.update({
+  id: '/discussion',
+  path: '/discussion',
   getParentRoute: () => rootRoute
 } as any);
 
@@ -67,11 +88,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CreateImport;
       parentRoute: typeof rootRoute;
     };
+    '/discussion': {
+      id: '/discussion';
+      path: '/discussion';
+      fullPath: '/discussion';
+      preLoaderRoute: typeof DiscussionImport;
+      parentRoute: typeof rootRoute;
+    };
     '/join': {
       id: '/join';
       path: '/join';
       fullPath: '/join';
       preLoaderRoute: typeof JoinImport;
+      parentRoute: typeof rootRoute;
+    };
+    '/presentation': {
+      id: '/presentation';
+      path: '/presentation';
+      fullPath: '/presentation';
+      preLoaderRoute: typeof PresentationImport;
+      parentRoute: typeof rootRoute;
+    };
+    '/watch_video': {
+      id: '/watch_video';
+      path: '/watch_video';
+      fullPath: '/watch_video';
+      preLoaderRoute: typeof WatchvideoImport;
       parentRoute: typeof rootRoute;
     };
     '/_auth/home': {
@@ -96,7 +138,10 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute;
   '/create': typeof CreateRoute;
+  '/discussion': typeof DiscussionRoute;
   '/join': typeof JoinRoute;
+  '/presentation': typeof PresentationRoute;
+  '/watch_video': typeof WatchvideoRoute;
   '/home': typeof AuthHomeRoute;
   '/login': typeof PublicLoginRoute;
 }
@@ -104,7 +149,10 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute;
   '/create': typeof CreateRoute;
+  '/discussion': typeof DiscussionRoute;
   '/join': typeof JoinRoute;
+  '/presentation': typeof PresentationRoute;
+  '/watch_video': typeof WatchvideoRoute;
   '/home': typeof AuthHomeRoute;
   '/login': typeof PublicLoginRoute;
 }
@@ -113,24 +161,55 @@ export interface FileRoutesById {
   __root__: typeof rootRoute;
   '/': typeof IndexRoute;
   '/create': typeof CreateRoute;
+  '/discussion': typeof DiscussionRoute;
   '/join': typeof JoinRoute;
+  '/presentation': typeof PresentationRoute;
+  '/watch_video': typeof WatchvideoRoute;
   '/_auth/home': typeof AuthHomeRoute;
   '/_public/login': typeof PublicLoginRoute;
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: '/' | '/create' | '/join' | '/home' | '/login';
+  fullPaths:
+    | '/'
+    | '/create'
+    | '/discussion'
+    | '/join'
+    | '/presentation'
+    | '/watch_video'
+    | '/home'
+    | '/login';
   fileRoutesByTo: FileRoutesByTo;
-  to: '/' | '/create' | '/join' | '/home' | '/login';
-  id: '__root__' | '/' | '/create' | '/join' | '/_auth/home' | '/_public/login';
+  to:
+    | '/'
+    | '/create'
+    | '/discussion'
+    | '/join'
+    | '/presentation'
+    | '/watch_video'
+    | '/home'
+    | '/login';
+  id:
+    | '__root__'
+    | '/'
+    | '/create'
+    | '/discussion'
+    | '/join'
+    | '/presentation'
+    | '/watch_video'
+    | '/_auth/home'
+    | '/_public/login';
   fileRoutesById: FileRoutesById;
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
   CreateRoute: typeof CreateRoute;
+  DiscussionRoute: typeof DiscussionRoute;
   JoinRoute: typeof JoinRoute;
+  PresentationRoute: typeof PresentationRoute;
+  WatchvideoRoute: typeof WatchvideoRoute;
   AuthHomeRoute: typeof AuthHomeRoute;
   PublicLoginRoute: typeof PublicLoginRoute;
 }
@@ -138,7 +217,10 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CreateRoute: CreateRoute,
+  DiscussionRoute: DiscussionRoute,
   JoinRoute: JoinRoute,
+  PresentationRoute: PresentationRoute,
+  WatchvideoRoute: WatchvideoRoute,
   AuthHomeRoute: AuthHomeRoute,
   PublicLoginRoute: PublicLoginRoute
 };
@@ -155,7 +237,10 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/create",
+        "/discussion",
         "/join",
+        "/presentation",
+        "/watch_video",
         "/_auth/home",
         "/_public/login"
       ]
@@ -166,8 +251,17 @@ export const routeTree = rootRoute
     "/create": {
       "filePath": "create.tsx"
     },
+    "/discussion": {
+      "filePath": "discussion.tsx"
+    },
     "/join": {
       "filePath": "join.tsx"
+    },
+    "/presentation": {
+      "filePath": "presentation.tsx"
+    },
+    "/watch_video": {
+      "filePath": "watch_video.tsx"
     },
     "/_auth/home": {
       "filePath": "_auth/home.tsx"

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,34 +1,81 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Header, ModeButton } from '../components';
 import { Speech, TvMinimalPlay, MessagesSquare } from 'lucide-react';
+import { useMemo } from 'react';
+
+// モードデータの型定義
+type ModeData = {
+  readonly id: string; // 一意の識別子(Primary key)
+  readonly text: string;
+  readonly to: string;
+  readonly icon: React.ReactNode;
+};
+
+// モードデータの定義
+const MODE_DATA: readonly ModeData[] = [
+  {
+    id: 'presentation',
+    text: 'プレゼンテーションモードを作成する',
+    to: '/presentation',
+    icon: <Speech />
+  },
+  {
+    id: 'watch_video',
+    text: '動画聴講モードを作成する',
+    to: '/watch_video',
+    icon: <TvMinimalPlay />
+  },
+  {
+    id: 'discussion',
+    text: 'ディスカッションモードを作成する',
+    to: '/discussion',
+    icon: <MessagesSquare />
+  }
+] as const; // モードデータを定数として外部化（再利用性向上）
 
 const Create: React.FC = () => {
+  // useMemoで不要な再レンダリングを防止
+  const modeData = useMemo(() => MODE_DATA, []);
+
+  // エラーハンドリング
+  if (!modeData || modeData.length === 0) {
+    // エラーメッセージを表示
+    return (
+      <div className='min-h-screen'>
+        <Header title='R-Streamを新規作成する' />
+        <main className='flex flex-1 flex-col items-center justify-center p-8'>
+          <div className='mb-8 text-center text-gray-600'>
+            <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
+            <p>シチュエーションに応じて、下記モードを選択してね</p>
+          </div>
+          {/* エラーメッセージ */}
+          <p className='text-center text-red-500'>
+            モードの読み込みに失敗しました
+          </p>
+        </main>
+      </div>
+    );
+  }
+  // 正常な場合
   return (
     <div className='min-h-screen'>
       <Header title='R-Streamを新規作成する' />
-
       <main className='flex flex-1 flex-col items-center justify-center p-8'>
         <div className='mb-8 text-center text-gray-600'>
           <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
           <p>シチュエーションに応じて、下記モードを選択してね</p>
         </div>
-        <div className='flex flex-col gap-4'>
-          <ModeButton
-            to='/presentation'
-            text='プレゼンテーションモードを作成する'
-            icon={<Speech className='h-6 w-6 text-white' />}
-          />
-          <ModeButton
-            to='/watch_video'
-            text='動画聴講モードを作成する'
-            icon={<TvMinimalPlay className='h-6 w-6 text-white' />}
-          />
-          <ModeButton
-            to='/discussion'
-            text='ディスカッションモードを作成する'
-            icon={<MessagesSquare className='h-6 w-6 text-white' />}
-          />
-        </div>
+        {/* モードボタン */}
+        <nav className='flex flex-col gap-4'>
+          {modeData.map((mode) => (
+            <ModeButton
+              key={mode.id}
+              text={mode.text}
+              to={mode.to}
+              icon={mode.icon}
+            />
+          ))}
+        </nav>
       </main>
     </div>
   );

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,8 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Header } from '../components';
-import PresentationIcon from '@mui/icons-material/CoPresent';
-import WatchVideoIcon from '@mui/icons-material/Duo';
-import DiscussionIcon from '@mui/icons-material/Forum';
+import { Speech, MonitorPlay, MessagesSquare } from 'lucide-react';
 
 const Create: React.FC = () => {
   return (
@@ -21,7 +19,7 @@ const Create: React.FC = () => {
             search={{ from: '/create' }}
             className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
           >
-            <PresentationIcon />
+            <Speech />
             <span>プレゼンテーションモードを作成する</span>
           </Link>
 
@@ -30,7 +28,7 @@ const Create: React.FC = () => {
             search={{ from: '/create' }}
             className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
           >
-            <WatchVideoIcon />
+            <MonitorPlay />
             <span>動画聴講モードを作成する</span>
           </Link>
 
@@ -39,7 +37,7 @@ const Create: React.FC = () => {
             search={{ from: '/create' }}
             className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
           >
-            <DiscussionIcon />
+            <MessagesSquare />
             <span>ディスカッションモードを作成する</span>
           </Link>
         </div>

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,6 +1,10 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { Header } from '../components';
-import { Speech, MonitorPlay, MessagesSquare } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
+import {
+  Header,
+  PresentationModeButton,
+  WatchVideoModeButton,
+  DiscussionModeButton
+} from '../components';
 
 const Create: React.FC = () => {
   return (
@@ -12,34 +16,10 @@ const Create: React.FC = () => {
           <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
           <p>シチュエーションに応じて、下記モードを選択してね</p>
         </div>
-
-        <div className='flex w-full max-w-md flex-col gap-4'>
-          <Link
-            to='/presentation'
-            search={{ from: '/create' }}
-            className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
-          >
-            <Speech />
-            <span>プレゼンテーションモードを作成する</span>
-          </Link>
-
-          <Link
-            to='/watch_video'
-            search={{ from: '/create' }}
-            className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
-          >
-            <MonitorPlay />
-            <span>動画聴講モードを作成する</span>
-          </Link>
-
-          <Link
-            to='/discussion'
-            search={{ from: '/create' }}
-            className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
-          >
-            <MessagesSquare />
-            <span>ディスカッションモードを作成する</span>
-          </Link>
+        <div className='space-y-4'>
+          <PresentationModeButton />
+          <WatchVideoModeButton />
+          <DiscussionModeButton />
         </div>
       </main>
     </div>

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,18 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Header, ModeButton } from '../components';
 import { Speech, TvMinimalPlay, MessagesSquare } from 'lucide-react';
-import { useMemo } from 'react';
-
-// モードデータの型定義
-type ModeData = {
-  readonly id: string; // 一意の識別子(Primary key)
-  readonly text: string;
-  readonly to: string;
-  readonly icon: React.ReactNode;
-};
 
 // モードデータの定義
-const MODE_DATA: readonly ModeData[] = [
+const MODE_DATA = [
   {
     id: 'presentation',
     text: 'プレゼンテーションモードを作成する',
@@ -34,29 +25,6 @@ const MODE_DATA: readonly ModeData[] = [
 ] as const; // モードデータを定数として外部化（再利用性向上）
 
 const Create: React.FC = () => {
-  // useMemoで不要な再レンダリングを防止
-  const modeData = useMemo(() => MODE_DATA, []);
-
-  // エラーハンドリング
-  if (!modeData || modeData.length === 0) {
-    // エラーメッセージを表示
-    return (
-      <div className='min-h-screen'>
-        <Header title='R-Streamを新規作成する' />
-        <main className='flex flex-1 flex-col items-center justify-center p-8'>
-          <div className='mb-8 text-center text-gray-600'>
-            <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
-            <p>シチュエーションに応じて、下記モードを選択してね</p>
-          </div>
-          {/* エラーメッセージ */}
-          <p className='text-center text-red-500'>
-            モードの読み込みに失敗しました
-          </p>
-        </main>
-      </div>
-    );
-  }
-  // 正常な場合
   return (
     <div className='min-h-screen'>
       <Header title='R-Streamを新規作成する' />
@@ -67,7 +35,7 @@ const Create: React.FC = () => {
         </div>
         {/* モードボタン */}
         <nav className='flex flex-col gap-4'>
-          {modeData.map((mode) => (
+          {MODE_DATA.map((mode) => (
             <ModeButton
               key={mode.id}
               text={mode.text}

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,34 +1,81 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Header, ModeButton } from '../components';
 import { Speech, TvMinimalPlay, MessagesSquare } from 'lucide-react';
+import { useMemo } from 'react';
+
+// モードデータの型定義
+type ModeData = {
+  readonly id: string; // 一意の識別子(Primary key)
+  readonly text: string;
+  readonly to: string;
+  readonly icon: React.ReactNode;
+};
+
+// モードデータの定義
+const MODE_DATA: readonly ModeData[] = [
+  {
+    id: 'presentation',
+    text: 'プレゼンテーションモードを作成する',
+    to: '/presentation',
+    icon: <Speech className='h-6 w-6 text-white' />
+  },
+  {
+    id: 'watch_video',
+    text: '動画聴講モードを作成する',
+    to: '/watch_video',
+    icon: <TvMinimalPlay className='h-6 w-6 text-white' />
+  },
+  {
+    id: 'discussion',
+    text: 'ディスカッションモードを作成する',
+    to: '/discussion',
+    icon: <MessagesSquare className='h-6 w-6 text-white' />
+  }
+] as const; // モードデータを定数として外部化（再利用性向上）
 
 const Create: React.FC = () => {
+  // useMemoで不要な再レンダリングを防止
+  const modeData = useMemo(() => MODE_DATA, []);
+
+  // エラーハンドリング
+  if (!modeData || modeData.length === 0) {
+    // エラーメッセージを表示
+    return (
+      <div className='min-h-screen'>
+        <Header title='R-Streamを新規作成する' />
+        <main className='flex flex-1 flex-col items-center justify-center p-8'>
+          <div className='mb-8 text-center text-gray-600'>
+            <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
+            <p>シチュエーションに応じて、下記モードを選択してね</p>
+          </div>
+          {/* エラーメッセージ */}
+          <p className='text-center text-red-500'>
+            モードの読み込みに失敗しました
+          </p>
+        </main>
+      </div>
+    );
+  }
+  // 正常な場合
   return (
     <div className='min-h-screen'>
       <Header title='R-Streamを新規作成する' />
-
       <main className='flex flex-1 flex-col items-center justify-center p-8'>
         <div className='mb-8 text-center text-gray-600'>
           <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
           <p>シチュエーションに応じて、下記モードを選択してね</p>
         </div>
-        <div className='flex flex-col gap-4'>
-          <ModeButton
-            to='/presentation'
-            text='プレゼンテーションモードを作成する'
-            icon={<Speech className='h-6 w-6 text-white' />}
-          />
-          <ModeButton
-            to='/watch_video'
-            text='動画聴講モードを作成する'
-            icon={<TvMinimalPlay className='h-6 w-6 text-white' />}
-          />
-          <ModeButton
-            to='/discussion'
-            text='ディスカッションモードを作成する'
-            icon={<MessagesSquare className='h-6 w-6 text-white' />}
-          />
-        </div>
+        {/* モードボタン */}
+        <nav className='flex flex-col gap-4'>
+          {modeData.map((mode) => (
+            <ModeButton
+              key={mode.id}
+              text={mode.text}
+              to={mode.to}
+              icon={mode.icon}
+            />
+          ))}
+        </nav>
       </main>
     </div>
   );

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,10 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
-import {
-  Header,
-  PresentationModeButton,
-  WatchVideoModeButton,
-  DiscussionModeButton
-} from '../components';
+import { Header, ModeButton } from '../components';
+import { Speech, TvMinimalPlay, MessagesSquare } from 'lucide-react';
 
 const Create: React.FC = () => {
   return (
@@ -16,10 +12,22 @@ const Create: React.FC = () => {
           <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
           <p>シチュエーションに応じて、下記モードを選択してね</p>
         </div>
-        <div className='space-y-4'>
-          <PresentationModeButton />
-          <WatchVideoModeButton />
-          <DiscussionModeButton />
+        <div className='flex flex-col gap-4'>
+          <ModeButton
+            to='/presentation'
+            text='プレゼンテーションモードを作成する'
+            icon={<Speech className='h-6 w-6 text-white' />}
+          />
+          <ModeButton
+            to='/watch_video'
+            text='動画聴講モードを作成する'
+            icon={<TvMinimalPlay className='h-6 w-6 text-white' />}
+          />
+          <ModeButton
+            to='/discussion'
+            text='ディスカッションモードを作成する'
+            icon={<MessagesSquare className='h-6 w-6 text-white' />}
+          />
         </div>
       </main>
     </div>

--- a/apps/web/src/routes/create.tsx
+++ b/apps/web/src/routes/create.tsx
@@ -1,17 +1,47 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 import { Header } from '../components';
+import PresentationIcon from '@mui/icons-material/CoPresent';
+import WatchVideoIcon from '@mui/icons-material/Duo';
+import DiscussionIcon from '@mui/icons-material/Forum';
 
 const Create: React.FC = () => {
   return (
     <div className='min-h-screen'>
       <Header title='R-Streamを新規作成する' />
 
-      <main className='flex flex-1 items-center justify-center p-8'>
-        <div className='text-center'>
-          <h2 className='mb-4 text-2xl font-bold text-gray-800'>
-            R-Streamを新規作成する
-          </h2>
-          <p className='text-gray-600'>この画面は開発中です</p>
+      <main className='flex flex-1 flex-col items-center justify-center p-8'>
+        <div className='mb-8 text-center text-gray-600'>
+          <p className='mb-4 text-lg'>R-Streamを新規作成する</p>
+          <p>シチュエーションに応じて、下記モードを選択してね</p>
+        </div>
+
+        <div className='flex w-full max-w-md flex-col gap-4'>
+          <Link
+            to='/presentation'
+            search={{ from: '/create' }}
+            className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
+          >
+            <PresentationIcon />
+            <span>プレゼンテーションモードを作成する</span>
+          </Link>
+
+          <Link
+            to='/watch_video'
+            search={{ from: '/create' }}
+            className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
+          >
+            <WatchVideoIcon />
+            <span>動画聴講モードを作成する</span>
+          </Link>
+
+          <Link
+            to='/discussion'
+            search={{ from: '/create' }}
+            className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
+          >
+            <DiscussionIcon />
+            <span>ディスカッションモードを作成する</span>
+          </Link>
         </div>
       </main>
     </div>

--- a/apps/web/src/routes/discussion.tsx
+++ b/apps/web/src/routes/discussion.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Header } from '../components';
+
+const Discussion: React.FC = () => {
+  return (
+    <div className='min-h-screen'>
+      <Header title='ディスカッションモード' />
+
+      <main className='flex flex-1 items-center justify-center p-8'>
+        <div className='text-center'>
+          <h2 className='mb-4 text-2xl font-bold text-gray-800'>
+            ディスカッションモードを開始する
+          </h2>
+          <p className='text-gray-600'>この画面は開発中です</p>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export const Route = createFileRoute('/discussion')({
+  component: Discussion
+});

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -13,7 +13,7 @@ const Index: React.FC = () => {
           <p>セッションを開始するか、既存のセッションに参加してください</p>
         </div>
 
-        <div className='flex w-full max-w-md flex-col gap-4'>
+        <nav className='flex w-full max-w-md flex-col gap-4'>
           <Link
             to='/create'
             search={{ from: '/' }}
@@ -31,7 +31,7 @@ const Index: React.FC = () => {
             <Users />
             <span>既存のR-Streamに参加する</span>
           </Link>
-        </div>
+        </nav>
       </main>
     </div>
   );

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Header } from '../components';
-import AddIcon from '@mui/icons-material/Add';
-import GroupIcon from '@mui/icons-material/Groups';
+import { Plus, Users } from 'lucide-react';
 
 const Index: React.FC = () => {
   return (
@@ -20,7 +19,7 @@ const Index: React.FC = () => {
             search={{ from: '/' }}
             className='flex items-center justify-center gap-3 rounded-lg bg-blue-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-blue-700'
           >
-            <AddIcon />
+            <Plus />
             <span>R-Streamを新規作成する</span>
           </Link>
 
@@ -29,7 +28,7 @@ const Index: React.FC = () => {
             search={{ from: '/' }}
             className='flex items-center justify-center gap-3 rounded-lg bg-gray-600 px-6 py-4 font-semibold text-white transition-colors duration-200 hover:bg-gray-700'
           >
-            <GroupIcon />
+            <Users />
             <span>既存のR-Streamに参加する</span>
           </Link>
         </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Header } from '../components';
 import AddIcon from '@mui/icons-material/Add';
-import GroupIcon from '@mui/icons-material/Group';
+import GroupIcon from '@mui/icons-material/Groups';
 
 const Index: React.FC = () => {
   return (
@@ -11,7 +11,7 @@ const Index: React.FC = () => {
       <main className='flex flex-1 flex-col items-center justify-center p-8'>
         <div className='mb-8 text-center text-gray-600'>
           <p className='mb-4 text-lg'>R-Streamへようこそ！</p>
-          <p>セッションを開始するか、既存のセッションに参加してください。</p>
+          <p>セッションを開始するか、既存のセッションに参加してください</p>
         </div>
 
         <div className='flex w-full max-w-md flex-col gap-4'>

--- a/apps/web/src/routes/presentation.tsx
+++ b/apps/web/src/routes/presentation.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Header } from '../components';
+
+const Presentation: React.FC = () => {
+  return (
+    <div className='min-h-screen'>
+      <Header title='プレゼンテーションモード' />
+
+      <main className='flex flex-1 items-center justify-center p-8'>
+        <div className='text-center'>
+          <h2 className='mb-4 text-2xl font-bold text-gray-800'>
+            プレゼンテーションモードを開始する
+          </h2>
+          <p className='text-gray-600'>この画面は開発中です</p>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export const Route = createFileRoute('/presentation')({
+  component: Presentation
+});

--- a/apps/web/src/routes/watch_video.tsx
+++ b/apps/web/src/routes/watch_video.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Header } from '../components';
+
+const WatchVideo: React.FC = () => {
+  return (
+    <div className='min-h-screen'>
+      <Header title='動画聴講モード' />
+
+      <main className='flex flex-1 items-center justify-center p-8'>
+        <div className='text-center'>
+          <h2 className='mb-4 text-2xl font-bold text-gray-800'>
+            動画聴講モードを開始する
+          </h2>
+          <p className='text-gray-600'>この画面は開発中です</p>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export const Route = createFileRoute('/watch_video')({
+  component: WatchVideo
+});


### PR DESCRIPTION
関連 Issue: なし（新規機能追加）

変更内容:
- プレゼンテーションモード画面を追加 (/presentation)
- 動画聴講モード画面を追加 (/watch_video)
- ディスカッションモード画面を追加 (/discussion)
- create.tsxに3つのモード選択ボタンを追加（@mui/icons-material使用）
- index.tsxのアイコンをGroupIconに修正
- 各画面は開発中ステータスで実装

スクリーンショット等: UI変更あり（新規画面追加）

TODO:
- 各モードの詳細機能実装
- アイコンの最適化検討（Lucide Reactへの移行検討）

## 関連 Issue

- URL

## 変更内容

- どんな意図で何を変更したのかをレビュワーに伝わるように書く

## スクリーンショット等
<img width="960" height="734" alt="image" src="https://github.com/user-attachments/assets/c688b3a2-0a76-4967-93c0-5f44d26f38c8" />
<img width="960" height="734" alt="image" src="https://github.com/user-attachments/assets/4ac6f9dd-c140-4a6e-b812-c783c149a727" />
<img width="960" height="734" alt="image" src="https://github.com/user-attachments/assets/463fc2d8-6dd4-4358-b7fe-724f1f6a7bf4" />
<img width="960" height="734" alt="image" src="https://github.com/user-attachments/assets/4d68fb7f-354e-40d0-b4b7-01d69858e8bd" />

## TODO

- 積み残したことがあれば書く
